### PR TITLE
[ FIX ] Validación de herencia

### DIFF
--- a/automatic_crud/register.py
+++ b/automatic_crud/register.py
@@ -14,7 +14,7 @@ def register_models():
     
     for model in models:
 
-        if isinstance(model(),BaseModel):
+        if issubclass(model, BaseModel):
             try:
                 if model.__name__ not in exclude_models:
                     


### PR DESCRIPTION
Se está pasando de usar isinstance a issubclass
esto es debido a que crear instancias es innecesario y podría causar errores según la naturaleza del modelo
por ejemplo cuando los fields son de carácter obligatorios como podría ser el caso de OneToOneField.