### PR TITLE
Bugfix on detail endpoints for ajax CRUDs

### DIFF
--- a/automatic_crud/views_crud_ajax.py
+++ b/automatic_crud/views_crud_ajax.py
@@ -179,7 +179,7 @@ class BaseDetailAJAX(BaseCrud):
             return response
         
         self.data = get_object(self.model,self.kwargs['pk'])        
-        if instance is not None:
+        if self.data is not None:
             self.data = serialize(
                             'json',[self.data,],
                             fields = self.get_fields_for_model(),


### PR DESCRIPTION
Found a bug on AJAX CRUDs view for detail endpoint: `instance` referenced variable doesn't exists in that function. Replacing it with `self.data` solves the issue:

![MicrosoftTeams-image](https://user-images.githubusercontent.com/142350/143491907-8b2b1980-38fd-4049-a716-0048fa4f94ad.png)


